### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/control_methods/negative_normal/config.vsh.yaml
+++ b/src/control_methods/negative_normal/config.vsh.yaml
@@ -13,7 +13,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
 
 runners:
   - type: executable

--- a/src/control_methods/negative_shuffle/config.vsh.yaml
+++ b/src/control_methods/negative_shuffle/config.vsh.yaml
@@ -12,7 +12,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
 
 runners:
   - type: executable

--- a/src/control_methods/positive/config.vsh.yaml
+++ b/src/control_methods/positive/config.vsh.yaml
@@ -18,7 +18,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: SRTsim

--- a/src/methods/scdesign2/config.vsh.yaml
+++ b/src/methods/scdesign2/config.vsh.yaml
@@ -19,7 +19,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: apt
         packages: [r-bioc-singlecellexperiment, git]

--- a/src/methods/scdesign3_nb/config.vsh.yaml
+++ b/src/methods/scdesign3_nb/config.vsh.yaml
@@ -37,7 +37,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         github:

--- a/src/methods/scdesign3_poisson/config.vsh.yaml
+++ b/src/methods/scdesign3_poisson/config.vsh.yaml
@@ -37,7 +37,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: apt
         packages: [r-bioc-singlecellexperiment, git]

--- a/src/methods/sparsim/config.vsh.yaml
+++ b/src/methods/sparsim/config.vsh.yaml
@@ -18,7 +18,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: apt
         packages: [git, r-bioc-singlecellexperiment]

--- a/src/methods/splatter/config.vsh.yaml
+++ b/src/methods/splatter/config.vsh.yaml
@@ -17,7 +17,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: apt
         packages: r-bioc-splatter

--- a/src/methods/srtsim/config.vsh.yaml
+++ b/src/methods/srtsim/config.vsh.yaml
@@ -18,7 +18,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: SRTsim

--- a/src/methods/symsim/config.vsh.yaml
+++ b/src/methods/symsim/config.vsh.yaml
@@ -18,7 +18,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: SingleCellExperiment

--- a/src/methods/zinbwave/config.vsh.yaml
+++ b/src/methods/zinbwave/config.vsh.yaml
@@ -18,7 +18,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: apt
         packages: [r-bioc-splatter, r-bioc-zinbwave, r-bioc-singlecellexperiment]

--- a/src/metrics/downstream/config.vsh.yaml
+++ b/src/metrics/downstream/config.vsh.yaml
@@ -110,7 +110,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: 

--- a/src/metrics/ks_statistic_gene_cell/config.vsh.yaml
+++ b/src/metrics/ks_statistic_gene_cell/config.vsh.yaml
@@ -296,7 +296,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: [edger, sparseMatrixStats]

--- a/src/metrics/ks_statistic_sc_features/config.vsh.yaml
+++ b/src/metrics/ks_statistic_sc_features/config.vsh.yaml
@@ -57,7 +57,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc:

--- a/src/metrics/ks_statistic_spatial/config.vsh.yaml
+++ b/src/metrics/ks_statistic_spatial/config.vsh.yaml
@@ -75,7 +75,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/process_datasets/convert/config.vsh.yaml
+++ b/src/process_datasets/convert/config.vsh.yaml
@@ -10,7 +10,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: [SingleCellExperiment]

--- a/src/process_datasets/generate_sim_spatialcluster/config.vsh.yaml
+++ b/src/process_datasets/generate_sim_spatialcluster/config.vsh.yaml
@@ -35,7 +35,7 @@ test_resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: 

--- a/src/process_datasets/precompute_downstream/config.vsh.yaml
+++ b/src/process_datasets/precompute_downstream/config.vsh.yaml
@@ -31,7 +31,7 @@ test_resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         github: [xzhoulab/SPARK, stevexniu/spots]

--- a/src/process_datasets/sc_features/config.vsh.yaml
+++ b/src/process_datasets/sc_features/config.vsh.yaml
@@ -30,7 +30,7 @@ test_resources:
 
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         github:


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.